### PR TITLE
Added a "grid" field to pygame

### DIFF
--- a/Snake_Display.py
+++ b/Snake_Display.py
@@ -14,9 +14,12 @@ whiteRGB: tuple = (255, 255, 255)
 gridHorizontal: int = 16
 gridVertical: int = 9
 def makeGrid() -> None:
+    setattr(pygame, 'grid', {})
     boxHorizontal: int = displayHorizontal / gridHorizontal
     boxVertical: int = displayVertical / gridVertical
     for x in range(0, gridHorizontal):
+        pygame.grid[x] = {}
         for y in range (0, gridVertical):
             box: pygame.Rect = pygame.Rect(x*boxHorizontal, y*boxVertical, boxHorizontal, boxVertical)
+            pygame.grid[x][y] = box
             pygame.draw.rect(display, whiteRGB, box, 1)


### PR DESCRIPTION
The pygame class now has a "grid" field which accepts a coordinate lookup. For example pygame.grid[15][8] will get you the box in the bottom right corner of a 16x9 grid.