### PR TITLE
"displaySnake" no longer uses currentNode.next

### DIFF
--- a/Snake_Display.py
+++ b/Snake_Display.py
@@ -28,8 +28,7 @@ def makeGrid() -> None:
 greenRGB: tuple = (0, 255, 0)
 def displaySnake(snake) -> None:
     currentNode = snake.head
-    displaySnakeNode(currentNode)
-    while currentNode.next:
+    while currentNode:
         displaySnakeNode(currentNode)
         currentNode = currentNode.next
 def displaySnakeNode(snakeNode) -> None:


### PR DESCRIPTION
Previously "displaySnake" would only try to display a 'snakeNode' if that node had a node after it (or was the head). After this it would try to display the current node. This means that it would display the head, enter the loop, then display the head again before ending. I don't know why this worked with more than 2 but honestly I don't care to think about it right now.